### PR TITLE
Use Strong ETags

### DIFF
--- a/apps/institution-service/nodemon.json
+++ b/apps/institution-service/nodemon.json
@@ -1,0 +1,6 @@
+{
+  "watch": ["."],
+  "ext": "js,ts,json,env",
+  "ignore": ["./cypress/**"],
+  "exec": "ts-node src/app.ts"  
+}

--- a/apps/institution-service/src/app.ts
+++ b/apps/institution-service/src/app.ts
@@ -7,6 +7,7 @@ import { PORT } from "./shared/const";
 
 const app = express();
 
+app.set("etag", "strong");
 app.use(express.json()); // http://expressjs.com/en/api.html#express.json
 app.use(express.urlencoded({ extended: false })); // http://expressjs.com/en/5x/api.html#express.urlencoded
 app.use(logger("dev"));


### PR DESCRIPTION
Issue: https://universalconnect.atlassian.net/browse/UCP-155

https://restfulapi.net/caching/

The Widget will likely store the value of this header somewhere so that it can compare what it's version of the institution list with the version which comes back in the api response and decide if it needs to update the elastic search list or not.