### PR TITLE
Update turborepo to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       ],
       "devDependencies": {
         "husky": "^9.0.11",
-        "turbo": "^1.13.4"
+        "turbo": "^2.1.2"
       },
       "engines": {
         "node": ">=20"
@@ -18051,26 +18051,26 @@
       }
     },
     "node_modules/turbo": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.13.4.tgz",
-      "integrity": "sha512-1q7+9UJABuBAHrcC4Sxp5lOqYS5mvxRrwa33wpIyM18hlOCpRD/fTJNxZ0vhbMcJmz15o9kkVm743mPn7p6jpQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.1.2.tgz",
+      "integrity": "sha512-Jb0rbU4iHEVQ18An/YfakdIv9rKnd3zUfSE117EngrfWXFHo3RndVH96US3GsT8VHpwTncPePDBT2t06PaFLrw==",
       "dev": true,
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "1.13.4",
-        "turbo-darwin-arm64": "1.13.4",
-        "turbo-linux-64": "1.13.4",
-        "turbo-linux-arm64": "1.13.4",
-        "turbo-windows-64": "1.13.4",
-        "turbo-windows-arm64": "1.13.4"
+        "turbo-darwin-64": "2.1.2",
+        "turbo-darwin-arm64": "2.1.2",
+        "turbo-linux-64": "2.1.2",
+        "turbo-linux-arm64": "2.1.2",
+        "turbo-windows-64": "2.1.2",
+        "turbo-windows-arm64": "2.1.2"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.13.4.tgz",
-      "integrity": "sha512-A0eKd73R7CGnRinTiS7txkMElg+R5rKFp9HV7baDiEL4xTG1FIg/56Vm7A5RVgg8UNgG2qNnrfatJtb+dRmNdw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.1.2.tgz",
+      "integrity": "sha512-3TEBxHWh99h2yIzkuIigMEOXt/ItYQp0aPiJjPd1xN4oDcsKK5AxiFKPH9pdtfIBzYsY59kQhZiFj0ELnSP7Bw==",
       "cpu": [
         "x64"
       ],
@@ -18081,9 +18081,9 @@
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.13.4.tgz",
-      "integrity": "sha512-eG769Q0NF6/Vyjsr3mKCnkG/eW6dKMBZk6dxWOdrHfrg6QgfkBUk0WUUujzdtVPiUIvsh4l46vQrNVd9EOtbyA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.1.2.tgz",
+      "integrity": "sha512-he0miWNq2WxJzsH82jS2Z4MXpnkzn9SH8a79iPXiJkq25QREImucscM4RPasXm8wARp91pyysJMq6aasD45CeA==",
       "cpu": [
         "arm64"
       ],
@@ -18094,9 +18094,9 @@
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.13.4.tgz",
-      "integrity": "sha512-Bq0JphDeNw3XEi+Xb/e4xoKhs1DHN7OoLVUbTIQz+gazYjigVZvtwCvgrZI7eW9Xo1eOXM2zw2u1DGLLUfmGkQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.1.2.tgz",
+      "integrity": "sha512-fKUBcc0rK8Vdqv5a/E3CSpMBLG1bzwv+Q0Q83F8fG2ZfNCNKGbcEYABdonNZkkx141Rj03cZQFCgxu3MVEGU+A==",
       "cpu": [
         "x64"
       ],
@@ -18107,9 +18107,9 @@
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.13.4.tgz",
-      "integrity": "sha512-BJcXw1DDiHO/okYbaNdcWN6szjXyHWx9d460v6fCHY65G8CyqGU3y2uUTPK89o8lq/b2C8NK0yZD+Vp0f9VoIg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.1.2.tgz",
+      "integrity": "sha512-sV8Bpmm0WiuxgbhxymcC7wSsuxfBBieI98GegSwbr/bs1ANAgzCg93urIrdKdQ3/b31zZxQwcaP4FBF1wx1Qdg==",
       "cpu": [
         "arm64"
       ],
@@ -18120,9 +18120,9 @@
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.13.4.tgz",
-      "integrity": "sha512-OFFhXHOFLN7A78vD/dlVuuSSVEB3s9ZBj18Tm1hk3aW1HTWTuAw0ReN6ZNlVObZUHvGy8d57OAGGxf2bT3etQw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.1.2.tgz",
+      "integrity": "sha512-wcmIJZI9ORT9ykHGliFE6kWRQrlH930QGSjSgWC8uFChFFuOyUlvC7ttcxuSvU9VqC7NF4C+GVAcFJQ8lTjN7g==",
       "cpu": [
         "x64"
       ],
@@ -18133,9 +18133,9 @@
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.13.4.tgz",
-      "integrity": "sha512-u5A+VOKHswJJmJ8o8rcilBfU5U3Y1TTAfP9wX8bFh8teYF1ghP0EhtMRLjhtp6RPa+XCxHHVA2CiC3gbh5eg5g==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.1.2.tgz",
+      "integrity": "sha512-zdnXjrhk7YO6CP+Q5wPueEvOCLH4lDa6C4rrwiakcWcPgcQGbVozJlo4uaQ6awo8HLWQEvOwu84RkWTdLAc/Hw==",
       "cpu": [
         "arm64"
       ],

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "husky": "^9.0.11",
-    "turbo": "^1.13.4"
+    "turbo": "^2.1.2"
   },
   "engines": {
     "node": ">=20"

--- a/turbo.json
+++ b/turbo.json
@@ -1,20 +1,30 @@
 {
   "$schema": "https://turbo.build/schema.v1.json",
   "globalDependencies": [],
-  "pipeline": {
+  "tasks": {
     "build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist"]
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "dist"
+      ]
     },
     "lint": {
-      "dependsOn": ["^lint"]
+      "dependsOn": [
+        "^lint"
+      ]
     },
     "prettier": {
-      "dependsOn": ["^prettier"]
+      "dependsOn": [
+        "^prettier"
+      ]
     },
     "test": {
       "cache": false,
-      "dependsOn": ["^test"]
+      "dependsOn": [
+        "^test"
+      ]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
I used Turborepo's migration script `npx @turbo/codemod migrate` to make the necessary changes.