### PR TITLE
Fix prod environment config

### DIFF
--- a/apps/performance-service/package.json
+++ b/apps/performance-service/package.json
@@ -7,7 +7,7 @@
     "cypress:run": "cypress run",
     "dev": "concurrently --kill-others-on-fail \"nodemon ./src/app.ts\" \"npm run redisserver\" \"npm run start:influxDb\"",
     "start": "nodemon ./src/app.ts",
-    "prod": "PRODUCTION=true npm run dev",
+    "prod": "NODE_ENV=production npm run dev",
     "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0",
     "redisserver": "sh ./scripts/start-redis.sh",
     "prettier": "prettier . --check",

--- a/apps/performance-service/src/dotEnv.ts
+++ b/apps/performance-service/src/dotEnv.ts
@@ -1,7 +1,7 @@
 import dotenv from "dotenv";
 import path from "path";
 
-if (process.env.PRODUCTION === "true") {
+if (process.env.NODE_ENV === "production") {
   dotenv.config({
     path: path.join(__dirname, "../env/production.env"),
   });


### PR DESCRIPTION
using NODE_ENV is common practice and heroku supposedly sets NODE_ENV to production by default. I updated NODE_ENV on staging to be `staging`.