### PR TITLE
Add recordFailure flag to performance event object

### DIFF
--- a/apps/performance-service/cypress/e2e/general/connectionMetrics.cy.ts
+++ b/apps/performance-service/cypress/e2e/general/connectionMetrics.cy.ts
@@ -1,0 +1,62 @@
+import { ComboJobTypes } from "@repo/shared-utils";
+import {
+  getConnectionPerformanceData,
+  markSuccessfulEventRequest,
+  startConnectionEventRequest,
+} from "../../shared/utils/requests";
+import { runTokenInvalidCheck } from "../../shared/utils/authorization";
+
+describe("/events/:connectionId/performance", () => {
+  it("gets success status when requested with the proper permission", () => {
+    const uniqueConnectionId = crypto.randomUUID();
+    startConnectionEventRequest({
+      connectionId: uniqueConnectionId,
+      body: {
+        jobTypes: [ComboJobTypes.TRANSACTIONS],
+        institutionId: "test1",
+        aggregatorId: "test1",
+      },
+    });
+    markSuccessfulEventRequest(uniqueConnectionId).then((response) => {
+      expect(response.status).to.eq(200);
+    });
+
+    cy.wait(5000); // 5 seconds for Redis processing poller to process and cleanup the event
+
+    getConnectionPerformanceData(uniqueConnectionId).then((response) => {
+      expect(response.status).to.eq(200);
+      expect(response.body).to.exist;
+      expect(response.body).to.have.property(
+        "connectionId",
+        uniqueConnectionId,
+      );
+      expect(response.body).to.have.property(
+        "jobTypes",
+        ComboJobTypes.TRANSACTIONS,
+      );
+      expect(response.body).to.include({
+        institutionId: "test1",
+        aggregatorId: "test1",
+      });
+
+      expect(response.body).to.have.nested.property(
+        "successMetric.isSuccess",
+        true,
+      );
+      expect(response.body)
+        .to.have.nested.property("successMetric.timestamp")
+        .that.is.a("string");
+      expect(response.body)
+        .to.have.nested.property("durationMetric.jobDuration")
+        .that.is.a("number");
+      expect(response.body)
+        .to.have.nested.property("durationMetric.timestamp")
+        .that.is.a("string");
+    });
+  });
+
+  runTokenInvalidCheck({
+    url: `metrics/connection/MBR-123`,
+    method: "GET",
+  });
+});

--- a/apps/performance-service/cypress/e2e/general/eventLifeCycle.cy.ts
+++ b/apps/performance-service/cypress/e2e/general/eventLifeCycle.cy.ts
@@ -1,4 +1,6 @@
+import { ComboJobTypes } from "@repo/shared-utils";
 import {
+  getConnectionPerformanceData,
   markSuccessfulEventRequest,
   pauseConnectionEventRequest,
   startConnectionEventRequest,
@@ -20,7 +22,7 @@ describe("connection event life cycle", () => {
         expect(response.status).to.eq(200);
       });
 
-      unpauseConnectionEventRequest(connectionId).then((response) => {
+      unpauseConnectionEventRequest({ connectionId }).then((response) => {
         expect(response.status).to.eq(200);
       });
 
@@ -29,12 +31,99 @@ describe("connection event life cycle", () => {
       });
 
       cy.wait(5000); // 5 seconds for Redis processing poller to process and cleanup the event
-      unpauseConnectionEventRequest(connectionId, false).then((response) => {
+
+      unpauseConnectionEventRequest({
+        connectionId,
+        failOnStatusCode: false,
+      }).then((response) => {
         expect(response.status).to.eq(400);
         expect(response.body).to.include({
           error: "Connection not found",
         });
       });
+
+      getConnectionPerformanceData(connectionId, false).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body).to.exist;
+        expect(response.body).to.have.property("connectionId", connectionId);
+        expect(response.body).to.have.nested.property(
+          "successMetric.isSuccess",
+          true,
+        );
+      });
     },
   );
+});
+
+describe("start, pause, resume, success. shouldRecordResult is false", () => {
+  it("creates an event, pauses it, unpauses it, and marks it successful then doesn't record it in the database", () => {
+    const connectionId = crypto.randomUUID();
+    const body = {
+      jobTypes: [ComboJobTypes.TRANSACTIONS],
+      institutionId: "testInstitutionId1",
+      aggregatorId: "testAggregatorId1",
+      recordDuration: true,
+      shouldRecordResult: false,
+    };
+
+    startConnectionEventRequest({ connectionId, body }).then((response) => {
+      expect(response.status).to.eq(201);
+    });
+
+    pauseConnectionEventRequest(connectionId).then((response) => {
+      expect(response.status).to.eq(200);
+    });
+
+    unpauseConnectionEventRequest({ connectionId }).then((response) => {
+      expect(response.status).to.eq(200);
+    });
+
+    markSuccessfulEventRequest(connectionId).then((response) => {
+      expect(response.status).to.eq(200);
+    });
+
+    cy.wait(5000); // 5 seconds for Redis processing poller to process and cleanup the event
+
+    getConnectionPerformanceData(connectionId, false).then((response) => {
+      expect(response.status).to.eq(404);
+      expect(response.body).to.exist;
+      expect(response.body).to.have.property(
+        "error",
+        "No performance data found for the specified connection ID",
+      );
+    });
+  });
+});
+
+describe("start, pause, resume with shouldRecordResult as true", () => {
+  it("creates an event, pauses it, unpauses it with shouldRecordResult and records a failure in the database", () => {
+    const connectionId = crypto.randomUUID();
+
+    startConnectionEventRequest({ connectionId }).then((response) => {
+      expect(response.status).to.eq(201);
+    });
+
+    pauseConnectionEventRequest(connectionId).then((response) => {
+      expect(response.status).to.eq(200);
+    });
+
+    unpauseConnectionEventRequest({
+      connectionId,
+      shouldRecordResult: true,
+    }).then((response) => {
+      expect(response.status).to.eq(200);
+    });
+
+    cy.wait(5000); // 5 seconds for Redis processing poller to process and cleanup the event
+
+    getConnectionPerformanceData(connectionId).then((response) => {
+      expect(response.status).to.eq(200);
+      expect(response.body).to.exist;
+      expect(response.body).to.have.property("connectionId", connectionId);
+      expect(response.body).to.have.nested.property(
+        "successMetric.isSuccess",
+        false,
+      );
+    });
+  });
 });

--- a/apps/performance-service/cypress/e2e/general/events.cy.ts
+++ b/apps/performance-service/cypress/e2e/general/events.cy.ts
@@ -102,7 +102,7 @@ describe("connection event endpoints", () => {
 
   describe("/events/:connectionId/connectionResume", () => {
     it("gets success status when requested with the proper permission", () => {
-      unpauseConnectionEventRequest(connectionId).then((response) => {
+      unpauseConnectionEventRequest({ connectionId }).then((response) => {
         expect(response.status).to.eq(200);
       });
     });

--- a/apps/performance-service/cypress/e2e/general/influx.cy.ts
+++ b/apps/performance-service/cypress/e2e/general/influx.cy.ts
@@ -56,7 +56,7 @@ describe("writing and reading influxDb", () => {
       if (testDataPoint.pauseDuration) {
         pauseConnectionEventRequest(connectionId);
         cy.wait(testDataPoint.pauseDuration);
-        unpauseConnectionEventRequest(connectionId);
+        unpauseConnectionEventRequest({ connectionId });
       }
 
       if (testDataPoint.successDuration) {

--- a/apps/performance-service/cypress/shared/utils/requests.ts
+++ b/apps/performance-service/cypress/shared/utils/requests.ts
@@ -11,6 +11,7 @@ interface ConnectionStartRequestBody {
   institutionId: string;
   aggregatorId: string;
   recordDuration?: boolean;
+  shouldRecordResult?: boolean;
 }
 
 export const testInstitutionId = "testInstitutionId";
@@ -51,10 +52,15 @@ export const pauseConnectionEventRequest = (connectionId: string) => {
   });
 };
 
-export const unpauseConnectionEventRequest = (
-  connectionId: string,
-  failOnStatusCode: boolean = true,
-) => {
+export const unpauseConnectionEventRequest = ({
+  connectionId,
+  failOnStatusCode = true,
+  shouldRecordResult,
+}: {
+  connectionId: string;
+  failOnStatusCode?: boolean;
+  shouldRecordResult?: boolean;
+}) => {
   return cy.request({
     url: `events/${connectionId}/connectionResume`,
     method: "PUT",
@@ -62,6 +68,7 @@ export const unpauseConnectionEventRequest = (
     headers: {
       Authorization: createAuthorizationHeader(WIDGET_ACCESS_TOKEN),
     },
+    body: { shouldRecordResult },
   });
 };
 
@@ -71,6 +78,20 @@ export const markSuccessfulEventRequest = (connectionId: string) => {
     method: "PUT",
     headers: {
       Authorization: createAuthorizationHeader(WIDGET_ACCESS_TOKEN),
+    },
+  });
+};
+
+export const getConnectionPerformanceData = (
+  connectionId: string,
+  failOnStatusCode: boolean = true,
+) => {
+  return cy.request({
+    url: `metrics/connection/${connectionId}`,
+    method: "GET",
+    failOnStatusCode,
+    headers: {
+      Authorization: createAuthorizationHeader(UCP_UI_USER_ACCESS_TOKEN),
     },
   });
 };

--- a/apps/performance-service/openApi.json
+++ b/apps/performance-service/openApi.json
@@ -1064,6 +1064,91 @@
           }
         }
       }
+    },
+    "/metrics/connection/{connectionId}": {
+      "get": {
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Get performance data for a single connection",
+        "description": "Retrieves performance metrics including success and duration data for a specific connection",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the connection to fetch performance data for",
+            "example": "MBR-1231"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "example": {
+                  "connectionId": "MBR-1231",
+                  "jobTypes": "transactions",
+                  "institutionId": "5e498f60-3496-4299-96ed-f8eb328ae8af",
+                  "aggregatorId": "mx",
+                  "successMetric": {
+                    "isSuccess": true,
+                    "timestamp": "2025-08-27T20:19:48.58953425Z"
+                  },
+                  "durationMetric": {
+                    "jobDuration": 1000000,
+                    "timestamp": "2025-08-27T20:19:48.589841791Z"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "error": "Invalid connection ID format"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Connection not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "error": "Connection not found"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/apps/performance-service/openApi.json
+++ b/apps/performance-service/openApi.json
@@ -784,6 +784,11 @@
                   "recordDuration": {
                     "type": "boolean",
                     "default": true
+                  },
+                  "shouldRecordResult": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether to record performance metrics for this connection"
                   }
                 }
               }
@@ -804,6 +809,7 @@
                       "institutionId": "13213-12312-123",
                       "aggregatorId": "mx",
                       "recordDuration": true,
+                      "shouldRecordResult": true,
                       "clientId": "54321",
                       "jobTypes": ["transactions"],
                       "startedAt": "2024-09-10T16:07:46.038Z"
@@ -851,6 +857,22 @@
             "description": "Connection ID from assigned aggregator"
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "shouldRecordResult": {
+                    "type": "boolean",
+                    "description": "Whether to record performance metrics for this connection. Only updates if value is true."
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Updated",
@@ -865,6 +887,7 @@
                       "institutionId": "13213-12312-123",
                       "aggregatorId": "mx",
                       "recordDuration": true,
+                      "shouldRecordResult": true,
                       "clientId": "54321",
                       "jobTypes": ["transactions"],
                       "userInteractionTime": 0,
@@ -915,6 +938,22 @@
             "description": "Connection ID from assigned aggregator"
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "shouldRecordResult": {
+                    "type": "boolean",
+                    "description": "Whether to record performance metrics for this connection. Only updates if value is true."
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Updated",
@@ -929,6 +968,7 @@
                       "institutionId": "13213-12312-123",
                       "aggregatorId": "mx",
                       "recordDuration": true,
+                      "shouldRecordResult": true,
                       "clientId": "54321",
                       "jobTypes": ["transactions"],
                       "userInteractionTime": 140,
@@ -993,6 +1033,7 @@
                       "institutionId": "13213-12312-123",
                       "aggregatorId": "mx",
                       "recordDuration": true,
+                      "shouldRecordResult": true,
                       "clientId": "54321",
                       "jobTypes": ["transactions"],
                       "userInteractionTime": 140,

--- a/apps/performance-service/src/app.ts
+++ b/apps/performance-service/src/app.ts
@@ -10,6 +10,7 @@ import performanceRoutingEndpoints from "./performanceRouting/performanceRouting
 import aggregatorGraphEndpoints from "./aggregatorGraphMetrics/aggregatorGraphEndpoints";
 import aggregatorMetricsEndpoints from "./aggregatorMetrics/aggregatorMetricsEndpoints";
 import institutionPerformanceEndpoints from "./institutionPerformance/institutionPerformanceEndpoints";
+import connectionMetricsEndpoints from "./connectionMetrics/connectionMetricsEndpoints";
 
 const app = express();
 
@@ -53,6 +54,7 @@ app.use(aggregatorGraphEndpoints);
 app.use(performanceRoutingEndpoints);
 app.use(aggregatorMetricsEndpoints);
 app.use(institutionPerformanceEndpoints);
+app.use(connectionMetricsEndpoints);
 
 app.listen(process.env.PORT || PORT, () => {
   console.info(

--- a/apps/performance-service/src/connectionMetrics/connectionMetricsEndpoints.ts
+++ b/apps/performance-service/src/connectionMetrics/connectionMetricsEndpoints.ts
@@ -1,0 +1,14 @@
+import { RequestHandler, Router } from "express";
+
+import { validateUIAudience } from "../middlewares/validationMiddleware";
+import { getConnectionPerformanceData } from "./connectionMetricsHandlers";
+
+const router = Router();
+
+router.get(
+  "/metrics/connection/:connectionId",
+  [validateUIAudience],
+  getConnectionPerformanceData as RequestHandler,
+);
+
+export default router;

--- a/apps/performance-service/src/connectionMetrics/connectionMetricsHandlers.test.ts
+++ b/apps/performance-service/src/connectionMetrics/connectionMetricsHandlers.test.ts
@@ -1,0 +1,75 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+import { getConnectionPerformanceData } from "./connectionMetricsHandlers";
+import { recordPerformanceMetric } from "../services/influxDb";
+import { ComboJobTypes } from "@repo/shared-utils";
+import { Request, Response } from "express";
+import { wait } from "../shared/tests/utils";
+
+describe("getConnectionPerformanceData", () => {
+  const connectionId = "MBR-123";
+  it("gets 404 when no performance data is found", async () => {
+    const req = {
+      params: {
+        connectionId,
+      },
+    } as unknown as Request;
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    } as unknown as Response;
+
+    await getConnectionPerformanceData(req, res);
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "No performance data found for the specified connection ID",
+    });
+  });
+
+  it("gets 200 when performance data is found", async () => {
+    const connectionId = "test1";
+    const req = {
+      params: {
+        connectionId,
+      },
+    } as unknown as Request;
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    } as unknown as Response;
+
+    await recordPerformanceMetric({
+      connectionId,
+      pausedAt: null,
+      clientId: "client_456",
+      jobTypes: [ComboJobTypes.ACCOUNT_NUMBER],
+      institutionId: "testInstitution",
+      aggregatorId: "mx",
+      startedAt: 1700000000000,
+      userInteractionTime: 0,
+      recordDuration: true,
+      shouldRecordResult: true,
+    });
+
+    await wait(2000);
+
+    await getConnectionPerformanceData(req, res);
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      aggregatorId: "mx",
+      connectionId: "test1",
+      institutionId: "testInstitution",
+      jobTypes: "accountNumber",
+      successMetric: {
+        isSuccess: false,
+        timestamp: expect.any(String),
+      },
+    });
+  });
+});

--- a/apps/performance-service/src/connectionMetrics/connectionMetricsHandlers.ts
+++ b/apps/performance-service/src/connectionMetrics/connectionMetricsHandlers.ts
@@ -1,0 +1,28 @@
+import { getPerformanceDataByConnectionId } from "../services/influxDb";
+import { Request, Response } from "express";
+
+export const getConnectionPerformanceData = async (
+  req: Request,
+  res: Response,
+) => {
+  try {
+    const { connectionId } = req.params;
+
+    const performanceData =
+      await getPerformanceDataByConnectionId(connectionId);
+
+    if (!performanceData) {
+      res.status(404).json({
+        error: "No performance data found for the specified connection ID",
+      });
+      return;
+    }
+
+    res.status(200).json(performanceData);
+  } catch (error) {
+    console.error("Error retrieving performance data:", error);
+    res.status(500).json({
+      error: "Failed to retrieve performance data",
+    });
+  }
+};

--- a/apps/performance-service/src/controllers/eventController.test.ts
+++ b/apps/performance-service/src/controllers/eventController.test.ts
@@ -68,7 +68,7 @@ describe("eventController", () => {
         clientId,
         startedAt: expect.any(Number),
         recordDuration: true,
-        recordFailure: true,
+        shouldRecordResult: true,
       });
 
       await expectRedisEventToEqual(connectionId, expectedUpdatedBody);
@@ -111,7 +111,7 @@ describe("eventController", () => {
         clientId,
         startedAt: expect.any(Number),
         recordDuration: false,
-        recordFailure: true,
+        shouldRecordResult: true,
       });
 
       await expectRedisEventToEqual(connectionId, expectedUpdatedBody);
@@ -163,7 +163,7 @@ describe("eventController", () => {
         connectionId,
         expect.objectContaining({
           startedAt: expect.any(Number),
-          recordFailure: true,
+          shouldRecordResult: true,
         }),
       );
     });
@@ -213,7 +213,7 @@ describe("eventController", () => {
       const expectedUpdatedBody = expect.objectContaining({
         pausedAt: expect.any(Number),
         userInteractionTime: 0,
-        recordFailure: true,
+        shouldRecordResult: true,
       });
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -226,7 +226,7 @@ describe("eventController", () => {
       await expectRedisEventToEqual(connectionId, expectedUpdatedBody);
     });
 
-    it("should update recordFailure status even when already paused", async () => {
+    it("should update shouldRecordResult status even when already paused", async () => {
       const res = {
         json: jest.fn(),
         status: jest.fn().mockReturnThis(),
@@ -234,21 +234,21 @@ describe("eventController", () => {
 
       const req = {
         ...mockRequest,
-        body: { recordFailure: false },
+        body: { shouldRecordResult: false },
       } as unknown as Request;
 
       await createStartEvent(req, preCheckMockResponse);
 
       const pauseReq = {
         ...mockRequest,
-        body: { recordFailure: false },
+        body: { shouldRecordResult: false },
       } as unknown as Request;
 
       await updateConnectionPause(pauseReq, preCheckMockResponse);
 
       const updateReq = {
         ...mockRequest,
-        body: { recordFailure: true },
+        body: { shouldRecordResult: true },
       } as unknown as Request;
 
       await updateConnectionPause(updateReq, res);
@@ -259,12 +259,12 @@ describe("eventController", () => {
         message:
           "Connection process was already paused. But failure detected status updated.",
         event: expect.objectContaining({
-          recordFailure: true,
+          shouldRecordResult: true,
         }),
       });
     });
 
-    it("should not update recordFailure from true to false when already paused", async () => {
+    it("should not update shouldRecordResult from true to false when already paused", async () => {
       const res = {
         json: jest.fn(),
         status: jest.fn().mockReturnThis(),
@@ -275,7 +275,7 @@ describe("eventController", () => {
 
       const updateReq = {
         ...mockRequest,
-        body: { recordFailure: false },
+        body: { shouldRecordResult: false },
       } as unknown as Request;
 
       await updateConnectionPause(updateReq, res);
@@ -285,7 +285,7 @@ describe("eventController", () => {
       expect(res.json).toHaveBeenCalledWith({
         message: "Connection process was already paused. Nothing changed.",
         event: expect.objectContaining({
-          recordFailure: true,
+          shouldRecordResult: true,
         }),
       });
     });
@@ -331,7 +331,7 @@ describe("eventController", () => {
         event: expect.objectContaining({
           pausedAt: pausedAtAlreadyTime,
           userInteractionTime: 0,
-          recordFailure: true,
+          shouldRecordResult: true,
         }),
       });
     });
@@ -354,7 +354,7 @@ describe("eventController", () => {
       const expectedUpdatedBody = expect.objectContaining({
         pausedAt: expect.any(Number),
         userInteractionTime,
-        recordFailure: true,
+        shouldRecordResult: true,
       });
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -417,7 +417,7 @@ describe("eventController", () => {
       const expectedUpdatedBody = expect.objectContaining({
         pausedAt: null,
         userInteractionTime: expect.any(Number),
-        recordFailure: true,
+        shouldRecordResult: true,
       });
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -434,7 +434,7 @@ describe("eventController", () => {
       await expectRedisEventToEqual(connectionId, expectedUpdatedBody);
     });
 
-    it("should update recordFailure to true when resuming", async () => {
+    it("should update shouldRecordResult to true when resuming", async () => {
       const res = {
         json: jest.fn(),
         status: jest.fn().mockReturnThis(),
@@ -443,7 +443,7 @@ describe("eventController", () => {
       const req = {
         ...mockRequest,
         body: {
-          recordFailure: false,
+          shouldRecordResult: false,
         },
       } as unknown as Request;
 
@@ -452,14 +452,14 @@ describe("eventController", () => {
 
       const updateReq = {
         ...mockRequest,
-        body: { recordFailure: true },
+        body: { shouldRecordResult: true },
       } as unknown as Request;
 
       await updateConnectionResume(updateReq, res);
 
       const expectedUpdatedBody = expect.objectContaining({
         pausedAt: null,
-        recordFailure: true,
+        shouldRecordResult: true,
       });
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -472,7 +472,7 @@ describe("eventController", () => {
       await expectRedisEventToEqual(connectionId, expectedUpdatedBody);
     });
 
-    it("should not update recordFailure from true to false when resuming", async () => {
+    it("should not update shouldRecordResult from true to false when resuming", async () => {
       const res = {
         json: jest.fn(),
         status: jest.fn().mockReturnThis(),
@@ -483,14 +483,14 @@ describe("eventController", () => {
 
       const updateReq = {
         ...mockRequest,
-        body: { recordFailure: false },
+        body: { shouldRecordResult: false },
       } as unknown as Request;
 
       await updateConnectionResume(updateReq, res);
 
       const expectedUpdatedBody = expect.objectContaining({
         pausedAt: null,
-        recordFailure: true,
+        shouldRecordResult: true,
       });
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -503,7 +503,7 @@ describe("eventController", () => {
       await expectRedisEventToEqual(connectionId, expectedUpdatedBody);
     });
 
-    it("should update recordFailure status even when not paused", async () => {
+    it("should update shouldRecordResult status even when not paused", async () => {
       const res = {
         json: jest.fn(),
         status: jest.fn().mockReturnThis(),
@@ -512,7 +512,7 @@ describe("eventController", () => {
       const req = {
         ...mockRequest,
         body: {
-          recordFailure: false,
+          shouldRecordResult: false,
         },
       } as unknown as Request;
 
@@ -520,7 +520,7 @@ describe("eventController", () => {
 
       const updateReq = {
         ...mockRequest,
-        body: { recordFailure: true },
+        body: { shouldRecordResult: true },
       } as unknown as Request;
 
       await updateConnectionResume(updateReq, res);
@@ -531,12 +531,12 @@ describe("eventController", () => {
         message:
           "Connection was not paused. But failure detected status updated.",
         event: expect.objectContaining({
-          recordFailure: true,
+          shouldRecordResult: true,
         }),
       });
     });
 
-    it("should not update recordFailure from true to false when not paused", async () => {
+    it("should not update shouldRecordResult from true to false when not paused", async () => {
       const res = {
         json: jest.fn(),
         status: jest.fn().mockReturnThis(),
@@ -546,7 +546,7 @@ describe("eventController", () => {
 
       const updateReq = {
         ...mockRequest,
-        body: { recordFailure: false },
+        body: { shouldRecordResult: false },
       } as unknown as Request;
 
       await updateConnectionResume(updateReq, res);
@@ -556,7 +556,7 @@ describe("eventController", () => {
       expect(res.json).toHaveBeenCalledWith({
         message: "Connection was not paused. Nothing changed.",
         event: expect.objectContaining({
-          recordFailure: true,
+          shouldRecordResult: true,
         }),
       });
     });
@@ -574,7 +574,7 @@ describe("eventController", () => {
       const expectedBody = expect.objectContaining({
         connectionId,
         startedAt: expect.any(Number),
-        recordFailure: true,
+        shouldRecordResult: true,
       });
 
       // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/apps/performance-service/src/controllers/eventController.test.ts
+++ b/apps/performance-service/src/controllers/eventController.test.ts
@@ -38,6 +38,11 @@ const expectRedisEventToEqual = async (
 };
 
 describe("eventController", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
   describe("createStartEvent", () => {
     it("should add the event to redis and return the event response with recordDuration defaulting to true", async () => {
       const clientId = "testClientId";
@@ -402,6 +407,7 @@ describe("eventController", () => {
     });
 
     it("should add userInteractionTime and nullify pausedAt and update the redis event", async () => {
+      jest.useFakeTimers();
       const res = {
         json: jest.fn(),
         status: jest.fn().mockReturnThis(),

--- a/apps/performance-service/src/controllers/eventController.test.ts
+++ b/apps/performance-service/src/controllers/eventController.test.ts
@@ -541,8 +541,7 @@ describe("eventController", () => {
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({
-        message:
-          "Connection was not paused. But failure detected status updated.",
+        message: "Connection was not paused. But shouldRecordResult updated.",
         event: expect.objectContaining({
           shouldRecordResult: true,
         }),

--- a/apps/performance-service/src/controllers/eventController.test.ts
+++ b/apps/performance-service/src/controllers/eventController.test.ts
@@ -241,10 +241,16 @@ describe("eventController", () => {
 
       const pauseReq = {
         ...mockRequest,
-        body: { shouldRecordResult: false },
       } as unknown as Request;
 
       await updateConnectionPause(pauseReq, preCheckMockResponse);
+      // Confirm that shouldRecordResult doesn't default to true
+      await expectRedisEventToEqual(
+        connectionId,
+        expect.objectContaining({
+          shouldRecordResult: false,
+        }),
+      );
 
       const updateReq = {
         ...mockRequest,
@@ -257,7 +263,7 @@ describe("eventController", () => {
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({
         message:
-          "Connection process was already paused. But failure detected status updated.",
+          "Connection process was already paused. But shouldRecordResult updated.",
         event: expect.objectContaining({
           shouldRecordResult: true,
         }),
@@ -403,7 +409,14 @@ describe("eventController", () => {
 
       const threeMinutes = 180000;
 
-      await createStartEvent(mockRequest, preCheckMockResponse);
+      const req = {
+        ...mockRequest,
+        body: {
+          shouldRecordResult: false,
+        },
+      } as unknown as Request;
+
+      await createStartEvent(req, preCheckMockResponse);
       await updateConnectionPause(mockRequest, preCheckMockResponse);
       jest.advanceTimersByTime(threeMinutes);
 
@@ -417,7 +430,7 @@ describe("eventController", () => {
       const expectedUpdatedBody = expect.objectContaining({
         pausedAt: null,
         userInteractionTime: expect.any(Number),
-        shouldRecordResult: true,
+        shouldRecordResult: false, // Confirm that shouldRecordResult doesn't default to true on pause and resume events
       });
 
       // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/apps/performance-service/src/controllers/eventController.test.ts
+++ b/apps/performance-service/src/controllers/eventController.test.ts
@@ -68,7 +68,7 @@ describe("eventController", () => {
         clientId,
         startedAt: expect.any(Number),
         recordDuration: true,
-        failureDetected: true,
+        recordFailure: true,
       });
 
       await expectRedisEventToEqual(connectionId, expectedUpdatedBody);
@@ -111,7 +111,7 @@ describe("eventController", () => {
         clientId,
         startedAt: expect.any(Number),
         recordDuration: false,
-        failureDetected: true,
+        recordFailure: true,
       });
 
       await expectRedisEventToEqual(connectionId, expectedUpdatedBody);
@@ -163,7 +163,7 @@ describe("eventController", () => {
         connectionId,
         expect.objectContaining({
           startedAt: expect.any(Number),
-          failureDetected: true,
+          recordFailure: true,
         }),
       );
     });
@@ -213,7 +213,7 @@ describe("eventController", () => {
       const expectedUpdatedBody = expect.objectContaining({
         pausedAt: expect.any(Number),
         userInteractionTime: 0,
-        failureDetected: true,
+        recordFailure: true,
       });
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -226,7 +226,7 @@ describe("eventController", () => {
       await expectRedisEventToEqual(connectionId, expectedUpdatedBody);
     });
 
-    it("should update failureDetected status even when already paused", async () => {
+    it("should update recordFailure status even when already paused", async () => {
       const res = {
         json: jest.fn(),
         status: jest.fn().mockReturnThis(),
@@ -234,21 +234,21 @@ describe("eventController", () => {
 
       const req = {
         ...mockRequest,
-        body: { failureDetected: false },
+        body: { recordFailure: false },
       } as unknown as Request;
 
       await createStartEvent(req, preCheckMockResponse);
 
       const pauseReq = {
         ...mockRequest,
-        body: { failureDetected: false },
+        body: { recordFailure: false },
       } as unknown as Request;
 
       await updateConnectionPause(pauseReq, preCheckMockResponse);
 
       const updateReq = {
         ...mockRequest,
-        body: { failureDetected: true },
+        body: { recordFailure: true },
       } as unknown as Request;
 
       await updateConnectionPause(updateReq, res);
@@ -259,12 +259,12 @@ describe("eventController", () => {
         message:
           "Connection process was already paused. But failure detected status updated.",
         event: expect.objectContaining({
-          failureDetected: true,
+          recordFailure: true,
         }),
       });
     });
 
-    it("should not update failureDetected from true to false when already paused", async () => {
+    it("should not update recordFailure from true to false when already paused", async () => {
       const res = {
         json: jest.fn(),
         status: jest.fn().mockReturnThis(),
@@ -275,7 +275,7 @@ describe("eventController", () => {
 
       const updateReq = {
         ...mockRequest,
-        body: { failureDetected: false },
+        body: { recordFailure: false },
       } as unknown as Request;
 
       await updateConnectionPause(updateReq, res);
@@ -285,7 +285,7 @@ describe("eventController", () => {
       expect(res.json).toHaveBeenCalledWith({
         message: "Connection process was already paused. Nothing changed.",
         event: expect.objectContaining({
-          failureDetected: true,
+          recordFailure: true,
         }),
       });
     });
@@ -331,7 +331,7 @@ describe("eventController", () => {
         event: expect.objectContaining({
           pausedAt: pausedAtAlreadyTime,
           userInteractionTime: 0,
-          failureDetected: true,
+          recordFailure: true,
         }),
       });
     });
@@ -354,7 +354,7 @@ describe("eventController", () => {
       const expectedUpdatedBody = expect.objectContaining({
         pausedAt: expect.any(Number),
         userInteractionTime,
-        failureDetected: true,
+        recordFailure: true,
       });
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -417,7 +417,7 @@ describe("eventController", () => {
       const expectedUpdatedBody = expect.objectContaining({
         pausedAt: null,
         userInteractionTime: expect.any(Number),
-        failureDetected: true,
+        recordFailure: true,
       });
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -434,7 +434,7 @@ describe("eventController", () => {
       await expectRedisEventToEqual(connectionId, expectedUpdatedBody);
     });
 
-    it("should update failureDetected to true when resuming", async () => {
+    it("should update recordFailure to true when resuming", async () => {
       const res = {
         json: jest.fn(),
         status: jest.fn().mockReturnThis(),
@@ -443,7 +443,7 @@ describe("eventController", () => {
       const req = {
         ...mockRequest,
         body: {
-          failureDetected: false,
+          recordFailure: false,
         },
       } as unknown as Request;
 
@@ -452,14 +452,14 @@ describe("eventController", () => {
 
       const updateReq = {
         ...mockRequest,
-        body: { failureDetected: true },
+        body: { recordFailure: true },
       } as unknown as Request;
 
       await updateConnectionResume(updateReq, res);
 
       const expectedUpdatedBody = expect.objectContaining({
         pausedAt: null,
-        failureDetected: true,
+        recordFailure: true,
       });
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -472,7 +472,7 @@ describe("eventController", () => {
       await expectRedisEventToEqual(connectionId, expectedUpdatedBody);
     });
 
-    it("should not update failureDetected from true to false when resuming", async () => {
+    it("should not update recordFailure from true to false when resuming", async () => {
       const res = {
         json: jest.fn(),
         status: jest.fn().mockReturnThis(),
@@ -483,14 +483,14 @@ describe("eventController", () => {
 
       const updateReq = {
         ...mockRequest,
-        body: { failureDetected: false },
+        body: { recordFailure: false },
       } as unknown as Request;
 
       await updateConnectionResume(updateReq, res);
 
       const expectedUpdatedBody = expect.objectContaining({
         pausedAt: null,
-        failureDetected: true,
+        recordFailure: true,
       });
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -503,7 +503,7 @@ describe("eventController", () => {
       await expectRedisEventToEqual(connectionId, expectedUpdatedBody);
     });
 
-    it("should update failureDetected status even when not paused", async () => {
+    it("should update recordFailure status even when not paused", async () => {
       const res = {
         json: jest.fn(),
         status: jest.fn().mockReturnThis(),
@@ -512,7 +512,7 @@ describe("eventController", () => {
       const req = {
         ...mockRequest,
         body: {
-          failureDetected: false,
+          recordFailure: false,
         },
       } as unknown as Request;
 
@@ -520,7 +520,7 @@ describe("eventController", () => {
 
       const updateReq = {
         ...mockRequest,
-        body: { failureDetected: true },
+        body: { recordFailure: true },
       } as unknown as Request;
 
       await updateConnectionResume(updateReq, res);
@@ -531,12 +531,12 @@ describe("eventController", () => {
         message:
           "Connection was not paused. But failure detected status updated.",
         event: expect.objectContaining({
-          failureDetected: true,
+          recordFailure: true,
         }),
       });
     });
 
-    it("should not update failureDetected from true to false when not paused", async () => {
+    it("should not update recordFailure from true to false when not paused", async () => {
       const res = {
         json: jest.fn(),
         status: jest.fn().mockReturnThis(),
@@ -546,7 +546,7 @@ describe("eventController", () => {
 
       const updateReq = {
         ...mockRequest,
-        body: { failureDetected: false },
+        body: { recordFailure: false },
       } as unknown as Request;
 
       await updateConnectionResume(updateReq, res);
@@ -556,7 +556,7 @@ describe("eventController", () => {
       expect(res.json).toHaveBeenCalledWith({
         message: "Connection was not paused. Nothing changed.",
         event: expect.objectContaining({
-          failureDetected: true,
+          recordFailure: true,
         }),
       });
     });
@@ -574,7 +574,7 @@ describe("eventController", () => {
       const expectedBody = expect.objectContaining({
         connectionId,
         startedAt: expect.any(Number),
-        failureDetected: true,
+        recordFailure: true,
       });
 
       // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/apps/performance-service/src/controllers/eventController.ts
+++ b/apps/performance-service/src/controllers/eventController.ts
@@ -100,7 +100,7 @@ export const updateConnectionPause = withClientAccess(
     try {
       const dateNow = Date.now();
       const { connectionId } = req.params;
-      const { shouldRecordResult = true } = req.body as {
+      const { shouldRecordResult } = req.body as {
         shouldRecordResult?: boolean;
       };
       const eventObj = (await getEvent(connectionId)) as EventObject;
@@ -108,7 +108,7 @@ export const updateConnectionPause = withClientAccess(
         let message = "Connection process was already paused. Nothing changed.";
         if (shouldRecordResult && !eventObj.shouldRecordResult) {
           message =
-            "Connection process was already paused. But failure detected status updated.";
+            "Connection process was already paused. But shouldRecordResult updated.";
           eventObj.shouldRecordResult = shouldRecordResult;
           await setEvent(connectionId, eventObj);
         }
@@ -139,7 +139,7 @@ export const updateConnectionResume = withClientAccess(
     try {
       const dateNow = Date.now();
       const { connectionId } = req.params;
-      const { shouldRecordResult = true } = req.body as {
+      const { shouldRecordResult } = req.body as {
         shouldRecordResult?: boolean;
       };
       const eventObj = (await getEvent(connectionId)) as EventObject;

--- a/apps/performance-service/src/controllers/eventController.ts
+++ b/apps/performance-service/src/controllers/eventController.ts
@@ -160,7 +160,7 @@ export const updateConnectionResume = withClientAccess(
         let message = "Connection was not paused. Nothing changed.";
         if (shouldRecordResult && !eventObj.shouldRecordResult) {
           message =
-            "Connection was not paused. But failure detected status updated.";
+            "Connection was not paused. But shouldRecordResult updated.";
           eventObj.shouldRecordResult = shouldRecordResult;
           await setEvent(connectionId, eventObj);
         }

--- a/apps/performance-service/src/controllers/eventController.ts
+++ b/apps/performance-service/src/controllers/eventController.ts
@@ -8,7 +8,7 @@ interface CreateStartRequest {
   institutionId: string;
   aggregatorId: string;
   recordDuration?: boolean;
-  recordFailure?: boolean;
+  shouldRecordResult?: boolean;
 }
 
 export interface EventObject {
@@ -20,7 +20,7 @@ export interface EventObject {
   startedAt: number;
   userInteractionTime: number;
   pausedAt: number | null | undefined;
-  recordFailure: boolean;
+  shouldRecordResult: boolean;
   successAt?: number;
   recordDuration: boolean;
 }
@@ -64,7 +64,7 @@ export const createStartEvent = async (req: Request, res: Response) => {
       institutionId,
       aggregatorId,
       recordDuration = true,
-      recordFailure = true,
+      shouldRecordResult = true,
     } = req.body as CreateStartRequest;
     const eventBody = {
       connectionId,
@@ -74,7 +74,7 @@ export const createStartEvent = async (req: Request, res: Response) => {
       jobTypes,
       startedAt: Date.now(),
       recordDuration,
-      recordFailure,
+      shouldRecordResult,
     };
     const eventObj = (await getEvent(connectionId)) as EventObject;
     if (eventObj) {
@@ -100,16 +100,16 @@ export const updateConnectionPause = withClientAccess(
     try {
       const dateNow = Date.now();
       const { connectionId } = req.params;
-      const { recordFailure = true } = req.body as {
-        recordFailure?: boolean;
+      const { shouldRecordResult = true } = req.body as {
+        shouldRecordResult?: boolean;
       };
       const eventObj = (await getEvent(connectionId)) as EventObject;
       if (eventObj.pausedAt) {
         let message = "Connection process was already paused. Nothing changed.";
-        if (recordFailure && !eventObj.recordFailure) {
+        if (shouldRecordResult && !eventObj.shouldRecordResult) {
           message =
             "Connection process was already paused. But failure detected status updated.";
-          eventObj.recordFailure = recordFailure;
+          eventObj.shouldRecordResult = shouldRecordResult;
           await setEvent(connectionId, eventObj);
         }
         res.status(200).json({
@@ -119,8 +119,8 @@ export const updateConnectionPause = withClientAccess(
       } else {
         eventObj.pausedAt = dateNow;
         eventObj.userInteractionTime = eventObj.userInteractionTime ?? 0;
-        if (recordFailure) {
-          eventObj.recordFailure = recordFailure;
+        if (shouldRecordResult) {
+          eventObj.shouldRecordResult = shouldRecordResult;
         }
         await setEvent(connectionId, eventObj);
         res.status(200).json({
@@ -139,16 +139,16 @@ export const updateConnectionResume = withClientAccess(
     try {
       const dateNow = Date.now();
       const { connectionId } = req.params;
-      const { recordFailure = true } = req.body as {
-        recordFailure?: boolean;
+      const { shouldRecordResult = true } = req.body as {
+        shouldRecordResult?: boolean;
       };
       const eventObj = (await getEvent(connectionId)) as EventObject;
       if (eventObj?.pausedAt) {
         const pauseDurationMilliseconds = dateNow - eventObj.pausedAt;
         eventObj.userInteractionTime += pauseDurationMilliseconds;
         eventObj.pausedAt = null;
-        if (recordFailure) {
-          eventObj.recordFailure = recordFailure;
+        if (shouldRecordResult) {
+          eventObj.shouldRecordResult = shouldRecordResult;
         }
 
         await setEvent(connectionId, eventObj);
@@ -158,10 +158,10 @@ export const updateConnectionResume = withClientAccess(
         });
       } else {
         let message = "Connection was not paused. Nothing changed.";
-        if (recordFailure && !eventObj.recordFailure) {
+        if (shouldRecordResult && !eventObj.shouldRecordResult) {
           message =
             "Connection was not paused. But failure detected status updated.";
-          eventObj.recordFailure = recordFailure;
+          eventObj.shouldRecordResult = shouldRecordResult;
           await setEvent(connectionId, eventObj);
         }
         res.status(200).json({

--- a/apps/performance-service/src/routes/eventRoutes.ts
+++ b/apps/performance-service/src/routes/eventRoutes.ts
@@ -24,6 +24,7 @@ const startEventSchema = Joi.object({
   institutionId: Joi.string().required(),
   aggregatorId: Joi.string().required(),
   recordDuration: Joi.boolean().optional(),
+  shouldRecordResult: Joi.boolean().optional(),
 });
 
 export const validateStartEventRequest =

--- a/apps/performance-service/src/services/influxDb.test.ts
+++ b/apps/performance-service/src/services/influxDb.test.ts
@@ -16,6 +16,7 @@ describe("recordPerformanceMetric", () => {
     successAt: 1700000005000,
     userInteractionTime: 2000,
     recordDuration: true,
+    failureDetected: true,
   };
 
   it("records correct duration and success metrics on successful event", async () => {
@@ -114,6 +115,7 @@ describe("recordPerformanceMetric", () => {
       ...event,
       institutionId: testInstitutionId,
       successAt: undefined,
+      failureDetected: true,
     });
     expect(result).toBe(true);
 
@@ -139,6 +141,33 @@ describe("recordPerformanceMetric", () => {
         jobTypes: "jobA|jobB",
       }),
     );
+
+    const durationDataPoint = await getLatestDataPoint(
+      "durationMetrics",
+      testInstitutionId,
+    );
+    expect(durationDataPoint).toBeNull();
+  });
+
+  it("should return true without recording metrics when successAt is undefined and failureDetected is false", async () => {
+    const testInstitutionId = `testNoRecord-${crypto.randomUUID()}`;
+
+    const result = await recordPerformanceMetric({
+      ...event,
+      institutionId: testInstitutionId,
+      successAt: undefined,
+      failureDetected: false,
+    });
+
+    expect(result).toBe(true);
+
+    await wait(2000);
+
+    const successDataPoint = await getLatestDataPoint(
+      "successRateMetrics",
+      testInstitutionId,
+    );
+    expect(successDataPoint).toBeNull();
 
     const durationDataPoint = await getLatestDataPoint(
       "durationMetrics",

--- a/apps/performance-service/src/services/influxDb.test.ts
+++ b/apps/performance-service/src/services/influxDb.test.ts
@@ -149,13 +149,12 @@ describe("recordPerformanceMetric", () => {
     expect(durationDataPoint).toBeNull();
   });
 
-  it("should return true without recording metrics when successAt is undefined and shouldRecordResult is false", async () => {
+  it("should return true without recording metrics when shouldRecordResult is false", async () => {
     const testInstitutionId = `testNoRecord-${crypto.randomUUID()}`;
 
     const result = await recordPerformanceMetric({
       ...event,
       institutionId: testInstitutionId,
-      successAt: undefined,
       shouldRecordResult: false,
     });
 

--- a/apps/performance-service/src/services/influxDb.test.ts
+++ b/apps/performance-service/src/services/influxDb.test.ts
@@ -16,7 +16,7 @@ describe("recordPerformanceMetric", () => {
     successAt: 1700000005000,
     userInteractionTime: 2000,
     recordDuration: true,
-    recordFailure: true,
+    shouldRecordResult: true,
   };
 
   it("records correct duration and success metrics on successful event", async () => {
@@ -115,7 +115,7 @@ describe("recordPerformanceMetric", () => {
       ...event,
       institutionId: testInstitutionId,
       successAt: undefined,
-      recordFailure: true,
+      shouldRecordResult: true,
     });
     expect(result).toBe(true);
 
@@ -149,14 +149,14 @@ describe("recordPerformanceMetric", () => {
     expect(durationDataPoint).toBeNull();
   });
 
-  it("should return true without recording metrics when successAt is undefined and recordFailure is false", async () => {
+  it("should return true without recording metrics when successAt is undefined and shouldRecordResult is false", async () => {
     const testInstitutionId = `testNoRecord-${crypto.randomUUID()}`;
 
     const result = await recordPerformanceMetric({
       ...event,
       institutionId: testInstitutionId,
       successAt: undefined,
-      recordFailure: false,
+      shouldRecordResult: false,
     });
 
     expect(result).toBe(true);

--- a/apps/performance-service/src/services/influxDb.test.ts
+++ b/apps/performance-service/src/services/influxDb.test.ts
@@ -16,7 +16,7 @@ describe("recordPerformanceMetric", () => {
     successAt: 1700000005000,
     userInteractionTime: 2000,
     recordDuration: true,
-    failureDetected: true,
+    recordFailure: true,
   };
 
   it("records correct duration and success metrics on successful event", async () => {
@@ -115,7 +115,7 @@ describe("recordPerformanceMetric", () => {
       ...event,
       institutionId: testInstitutionId,
       successAt: undefined,
-      failureDetected: true,
+      recordFailure: true,
     });
     expect(result).toBe(true);
 
@@ -149,14 +149,14 @@ describe("recordPerformanceMetric", () => {
     expect(durationDataPoint).toBeNull();
   });
 
-  it("should return true without recording metrics when successAt is undefined and failureDetected is false", async () => {
+  it("should return true without recording metrics when successAt is undefined and recordFailure is false", async () => {
     const testInstitutionId = `testNoRecord-${crypto.randomUUID()}`;
 
     const result = await recordPerformanceMetric({
       ...event,
       institutionId: testInstitutionId,
       successAt: undefined,
-      failureDetected: false,
+      recordFailure: false,
     });
 
     expect(result).toBe(true);

--- a/apps/performance-service/src/services/influxDb.ts
+++ b/apps/performance-service/src/services/influxDb.ts
@@ -62,7 +62,7 @@ async function writeData(data: {
 export const recordPerformanceMetric = async (
   event: EventObject,
 ): Promise<boolean> => {
-  if (!event.successAt && !event.shouldRecordResult) {
+  if (!event.shouldRecordResult) {
     return true; // Delete the performance object without recording the data
   }
 

--- a/apps/performance-service/src/services/influxDb.ts
+++ b/apps/performance-service/src/services/influxDb.ts
@@ -62,7 +62,7 @@ async function writeData(data: {
 export const recordPerformanceMetric = async (
   event: EventObject,
 ): Promise<boolean> => {
-  if (!event.successAt && !event.recordFailure) {
+  if (!event.successAt && !event.shouldRecordResult) {
     return true; // Delete the performance object without recording the data
   }
 

--- a/apps/performance-service/src/services/influxDb.ts
+++ b/apps/performance-service/src/services/influxDb.ts
@@ -28,6 +28,7 @@ async function writeData(data: {
   isSuccess: boolean;
   jobDuration: number;
   recordDuration: boolean;
+  connectionId: string;
 }): Promise<boolean> {
   try {
     if (data.isSuccess && data.recordDuration) {
@@ -36,6 +37,7 @@ async function writeData(data: {
         .tag("institutionId", data.institutionId)
         .tag("clientId", data.clientId)
         .tag("aggregatorId", data.aggregatorId)
+        .tag("connectionId", data.connectionId)
         .intField("jobDuration", data.jobDuration);
 
       writeApi.writePoint(durationPoint);
@@ -46,6 +48,7 @@ async function writeData(data: {
       .tag("institutionId", data.institutionId)
       .tag("clientId", data.clientId)
       .tag("aggregatorId", data.aggregatorId)
+      .tag("connectionId", data.connectionId)
       .intField("isSuccess", data.isSuccess ? 1 : 0);
 
     writeApi.writePoint(successRatePoint);
@@ -80,5 +83,93 @@ export const recordPerformanceMetric = async (
     isSuccess: !!event.successAt,
     jobDuration: totalDuration,
     recordDuration: event.recordDuration,
+    connectionId: event.connectionId,
   });
+};
+
+interface PerformanceData {
+  connectionId: string;
+  jobTypes: string;
+  institutionId: string;
+  aggregatorId: string;
+  durationMetric?: {
+    jobDuration: number;
+    timestamp: string;
+  };
+  successMetric: {
+    isSuccess: boolean;
+    timestamp: string;
+  };
+}
+
+interface InfluxQueryResult {
+  _time: string;
+  _value: number;
+  jobTypes: string;
+  institutionId: string;
+  aggregatorId: string;
+  connectionId: string;
+}
+
+export const getPerformanceDataByConnectionId = async (
+  connectionId: string,
+): Promise<PerformanceData | null> => {
+  try {
+    const successQuery = `
+      from(bucket: "${BUCKET}")
+      |> range(start: -30d)
+      |> filter(fn: (r) => r._measurement == "successRateMetrics")
+      |> filter(fn: (r) => r.connectionId == "${connectionId}")
+      |> last()
+    `;
+
+    const successResults =
+      await queryApi.collectRows<InfluxQueryResult>(successQuery);
+
+    if (successResults.length === 0) {
+      return null;
+    }
+
+    const durationQuery = `
+      from(bucket: "${BUCKET}")
+      |> range(start: -30d)
+      |> filter(fn: (r) => r._measurement == "durationMetrics")
+      |> filter(fn: (r) => r.connectionId == "${connectionId}")
+      |> last()
+    `;
+
+    const durationResults =
+      await queryApi.collectRows<InfluxQueryResult>(durationQuery);
+
+    if (successResults.length === 0) {
+      return null;
+    }
+
+    const successResult = successResults[0];
+    const durationResult =
+      durationResults.length > 0 ? durationResults[0] : null;
+
+    const performanceData: PerformanceData = {
+      connectionId,
+      jobTypes: successResult.jobTypes,
+      institutionId: successResult.institutionId,
+      aggregatorId: successResult.aggregatorId,
+      successMetric: {
+        isSuccess: successResult._value === 1,
+        timestamp: successResult._time,
+      },
+    };
+
+    if (durationResult) {
+      performanceData.durationMetric = {
+        jobDuration: durationResult._value,
+        timestamp: durationResult._time,
+      };
+    }
+
+    return performanceData;
+  } catch (error) {
+    console.error("Error querying InfluxDB:", error);
+    throw error;
+  }
 };

--- a/apps/performance-service/src/services/influxDb.ts
+++ b/apps/performance-service/src/services/influxDb.ts
@@ -62,6 +62,10 @@ async function writeData(data: {
 export const recordPerformanceMetric = async (
   event: EventObject,
 ): Promise<boolean> => {
+  if (!event.successAt && !event.failureDetected) {
+    return true; // Delete the performance object without recording the data
+  }
+
   const jobTypesKey = [...event.jobTypes].sort().join("|");
 
   const totalDuration = event?.successAt

--- a/apps/performance-service/src/services/influxDb.ts
+++ b/apps/performance-service/src/services/influxDb.ts
@@ -62,7 +62,7 @@ async function writeData(data: {
 export const recordPerformanceMetric = async (
   event: EventObject,
 ): Promise<boolean> => {
-  if (!event.successAt && !event.failureDetected) {
+  if (!event.successAt && !event.recordFailure) {
     return true; // Delete the performance object without recording the data
   }
 

--- a/apps/performance-service/src/shared/tests/testData/influx.ts
+++ b/apps/performance-service/src/shared/tests/testData/influx.ts
@@ -18,6 +18,7 @@ export const createTestScenarioEvents = async (
       successAt: 1700000010000,
       userInteractionTime: 0,
       recordDuration: true,
+      shouldRecordResult: true,
     },
     {
       connectionId: "MBR-123",
@@ -29,6 +30,7 @@ export const createTestScenarioEvents = async (
       startedAt: 1700000000000,
       userInteractionTime: 0,
       recordDuration: true,
+      shouldRecordResult: true,
     },
     {
       connectionId: "MBR-123",
@@ -41,6 +43,7 @@ export const createTestScenarioEvents = async (
       successAt: 1700000030000,
       userInteractionTime: 0,
       recordDuration: true,
+      shouldRecordResult: true,
     },
     {
       connectionId: "MBR-123",
@@ -53,6 +56,7 @@ export const createTestScenarioEvents = async (
       successAt: 1700000020000,
       userInteractionTime: 0,
       recordDuration: true,
+      shouldRecordResult: true,
     },
     {
       connectionId: "MBR-123",
@@ -65,6 +69,7 @@ export const createTestScenarioEvents = async (
       successAt: 1700000010000,
       userInteractionTime: 0,
       recordDuration: true,
+      shouldRecordResult: true,
     },
     {
       connectionId: "MBR-123",
@@ -76,6 +81,7 @@ export const createTestScenarioEvents = async (
       startedAt: 1700000000000,
       userInteractionTime: 0,
       recordDuration: true,
+      shouldRecordResult: true,
     },
     {
       connectionId: "MBR-123",
@@ -87,6 +93,7 @@ export const createTestScenarioEvents = async (
       startedAt: 1700000000000,
       userInteractionTime: 0,
       recordDuration: true,
+      shouldRecordResult: true,
     },
     {
       connectionId: "MBR-123",
@@ -98,6 +105,7 @@ export const createTestScenarioEvents = async (
       startedAt: 1700000000000,
       userInteractionTime: 0,
       recordDuration: true,
+      shouldRecordResult: true,
     },
     {
       connectionId: "MBR-123",
@@ -109,6 +117,7 @@ export const createTestScenarioEvents = async (
       startedAt: 1700000000000,
       userInteractionTime: 0,
       recordDuration: true,
+      shouldRecordResult: true,
     },
     {
       connectionId: "MBR-123",
@@ -121,6 +130,7 @@ export const createTestScenarioEvents = async (
       successAt: 1700000030000,
       userInteractionTime: 0,
       recordDuration: true,
+      shouldRecordResult: true,
     },
     {
       connectionId: "MBR-123",
@@ -133,6 +143,7 @@ export const createTestScenarioEvents = async (
       successAt: 1700000010000,
       userInteractionTime: 5000,
       recordDuration: true,
+      shouldRecordResult: true,
     },
     {
       connectionId: "MBR-123",
@@ -145,6 +156,7 @@ export const createTestScenarioEvents = async (
       successAt: 1700000010000,
       userInteractionTime: 5000,
       recordDuration: true,
+      shouldRecordResult: true,
     },
     {
       connectionId: "MBR-123",
@@ -156,6 +168,7 @@ export const createTestScenarioEvents = async (
       startedAt: 1700000000000,
       userInteractionTime: 0,
       recordDuration: true,
+      shouldRecordResult: true,
     },
   ];
 

--- a/apps/performance-service/src/shared/tests/utils.ts
+++ b/apps/performance-service/src/shared/tests/utils.ts
@@ -114,6 +114,7 @@ interface SeedInfluxTestDbParams {
   institutionId?: string;
   clientId?: string;
   aggregatorId?: string;
+  connectionId?: string;
   duration?: number | undefined;
   timestamp?: Date;
   success?: boolean;
@@ -125,6 +126,7 @@ export const seedInfluxTestDb = async ({
   institutionId = testInstitutionId,
   clientId = "testClient",
   aggregatorId = "mx",
+  connectionId = "testConnection",
   duration,
   timestamp = new Date(),
   success = true,
@@ -138,6 +140,7 @@ export const seedInfluxTestDb = async ({
       .tag("institutionId", institutionId)
       .tag("clientId", clientId)
       .tag("aggregatorId", aggregatorId)
+      .tag("connectionId", connectionId)
       .intField("jobDuration", duration)
       .timestamp(timestamp);
 
@@ -149,6 +152,7 @@ export const seedInfluxTestDb = async ({
     .tag("institutionId", institutionId)
     .tag("clientId", clientId)
     .tag("aggregatorId", aggregatorId)
+    .tag("connectionId", connectionId)
     .intField("isSuccess", success ? 1 : 0)
     .timestamp(timestamp);
 


### PR DESCRIPTION
Add recordFailure flag.

* once shouldRecordResult is set to `true` there is no setting it back to false
* if shouldRecordResult is true performance will be recorded
